### PR TITLE
Added DJ role support

### DIFF
--- a/index.js
+++ b/index.js
@@ -600,6 +600,11 @@ DubAPI.prototype.isResidentDJ = function(user) {
     return user.role === roles['resident-dj'].id;
 };
 
+DubAPI.prototype.isDJ = function(user) {
+    if (!this._.connected || user === undefined) return false;
+    return user.role === roles['dj'].id;
+};
+
 DubAPI.prototype.isStaff = function(user) {
     if (!this._.connected || user === undefined) return false;
     return user.role !== null;

--- a/lib/data/roles.js
+++ b/lib/data/roles.js
@@ -80,7 +80,9 @@ roles['dj'] = roles['564435423f6ba174d2000001'] = {
     id: '564435423f6ba174d2000001',
     type: 'dj',
     label: 'DJ',
-    rights: []
+    rights: [
+        'set-dj'
+    ]
 };
 
 module.exports = roles;

--- a/lib/data/roles.js
+++ b/lib/data/roles.js
@@ -76,4 +76,11 @@ roles['resident-dj'] = roles['5615feb8e596154fc2000002'] = {
     ]
 };
 
+roles['dj'] = roles['564435423f6ba174d2000001'] = {
+    id: '564435423f6ba174d2000001',
+    type: 'dj',
+    label: 'DJ',
+    rights: []
+};
+
 module.exports = roles;


### PR DESCRIPTION
Added support for the DJ role.
Not 100% sure what the ‘set-dj’ means in the roles.
According to dub documentation RDJs can only participate in locked
queues. DJs shouldn’t be able to do that.
So I assumed that it would be exactly that right.